### PR TITLE
feat: 회원가입, 로그인 페이지 구현

### DIFF
--- a/src/components/signup/Steps.jsx
+++ b/src/components/signup/Steps.jsx
@@ -1,0 +1,30 @@
+// src/components/signup/Steps.jsx
+import React from 'react';
+
+const Steps = ({ currentStep }) => {
+  return (
+    <div className="w-full max-w-[600px] mb-8">
+      <div className="flex items-center">
+        <div className={`flex-1 text-center ${currentStep === 1 ? 'text-indigo-600 font-medium' : 'text-gray-500'}`}>
+          <div className="relative">
+            <div className={`w-8 h-8 mx-auto rounded-full flex items-center justify-center ${currentStep === 1 ? 'bg-indigo-600 text-white' : 'bg-gray-200'}`}>
+              1
+            </div>
+            <div className="mt-2">회원정보 입력</div>
+          </div>
+        </div>
+        <div className={`flex-1 border-t-2 ${currentStep === 2 ? 'border-indigo-600' : 'border-gray-200'}`}></div>
+        <div className={`flex-1 text-center ${currentStep === 2 ? 'text-indigo-600 font-medium' : 'text-gray-500'}`}>
+          <div className="relative">
+            <div className={`w-8 h-8 mx-auto rounded-full flex items-center justify-center ${currentStep === 2 ? 'bg-indigo-600 text-white' : 'bg-gray-200'}`}>
+              2
+            </div>
+            <div className="mt-2">토큰 지갑 생성</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Steps;

--- a/src/components/signup/WalletSuccessDialog.jsx
+++ b/src/components/signup/WalletSuccessDialog.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ClipboardIcon, CheckCircle } from 'lucide-react';
+
+const WalletSuccessDialog = ({ walletData }) => {
+  const navigate = useNavigate();
+  
+  const handleCopyToClipboard = (text) => {
+    navigator.clipboard.writeText(text);
+  };
+
+  const handleContinue = () => {
+    navigate('/auth/sign-in');
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-lg p-6">
+        <div className="flex items-center justify-center mb-4">
+          <CheckCircle className="w-10 h-10 text-green-500" />
+        </div>
+        
+        <h2 className="text-xl font-bold text-center text-gray-900 mb-4">
+          지갑 생성 완료
+        </h2>
+
+        <div className="space-y-4">
+          <div className="bg-yellow-50 border-l-4 border-yellow-400 p-3">
+            <p className="text-yellow-700 font-medium text-sm">
+              ⚠️ 아래 정보를 반드시 안전한 곳에 보관하세요
+            </p>
+          </div>
+
+          <div className="bg-blue-50 p-4 rounded">
+            <h3 className="text-base font-semibold text-blue-900 mb-2">임시 비밀번호</h3>
+            <div className="flex items-center justify-between bg-white p-3 rounded border border-blue-200">
+              <p className="text-lg font-mono text-blue-900">{walletData.temporaryPassword}</p>
+              <button
+                onClick={() => handleCopyToClipboard(walletData.temporaryPassword)}
+                className="p-1.5 hover:bg-blue-50 rounded-full"
+              >
+                <ClipboardIcon className="w-5 h-5 text-blue-600" />
+              </button>
+            </div>
+          </div>
+
+          <div className="p-4 bg-gray-50 rounded">
+            <h3 className="text-base font-semibold text-gray-700 mb-2">지갑 주소</h3>
+            <div className="flex items-center justify-between bg-white p-3 rounded border border-gray-200">
+              <p className="text-sm font-mono text-gray-600 break-all">{walletData.address}</p>
+              <button
+                onClick={() => handleCopyToClipboard(walletData.address)}
+                className="p-1.5 hover:bg-gray-50 rounded-full ml-2"
+              >
+                <ClipboardIcon className="w-5 h-5 text-gray-600" />
+              </button>
+            </div>
+          </div>
+
+          <div className="p-4 bg-gray-50 rounded text-sm text-gray-600">
+            <ul className="space-y-2">
+              <li>• 임시 비밀번호는 최초 1회만 제공됩니다</li>
+              <li>• 지갑 주소는 마이페이지에서 확인 가능합니다</li>
+              <li>• 키스토어 파일이 안전하게 저장되었습니다</li>
+            </ul>
+          </div>
+
+          <button
+            onClick={handleContinue}
+            className="w-full py-3 px-4 bg-indigo-600 text-white rounded font-medium hover:bg-indigo-700 text-sm mt-2"
+          >
+            로그인하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WalletSuccessDialog;

--- a/src/layouts/auth/index.jsx
+++ b/src/layouts/auth/index.jsx
@@ -1,67 +1,40 @@
-import Footer from "components/footer/FooterAuthDefault";
-import authImg from "assets/img/auth/auth.png";
-import { Link, Routes, Route, Navigate } from "react-router-dom";
-import routes from "routes.js";
-import FixedPlugin from "components/fixedPlugin/FixedPlugin";
+// src/layouts/auth/index.jsx
+import React from "react";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
+import Navbar from "components/navbar";
+import SignIn from "views/auth/SignIn";
+import SignUpStep1 from "views/auth/SignUpStep1";
+import SignUpStep2 from "views/auth/SignUpStep2";
 
-export default function Auth() {
-  const getRoutes = (routes) => {
-    return routes.map((prop, key) => {
-      if (prop.layout === "/auth") {
-        return (
-          <Route path={`/${prop.path}`} element={prop.component} key={key} />
-        );
-      } else {
-        return null;
-      }
-    });
-  };
-  document.documentElement.dir = "ltr";
+export default function AuthLayout(props) {
+  const { ...rest } = props;
+  const location = useLocation();
+  const [currentRoute, setCurrentRoute] = React.useState("Sign In");
+
+  React.useEffect(() => {
+    if (location.pathname.includes("/sign-in")) {
+      setCurrentRoute("Sign In");
+    } else if (location.pathname.includes("/signup")) {
+      setCurrentRoute("Sign Up");
+    }
+  }, [location.pathname]);
+
   return (
-    <div>
-      <div className="relative float-right h-full min-h-screen w-full !bg-white dark:!bg-navy-900">
-        <FixedPlugin />
-        <main className={`mx-auto min-h-screen`}>
-          <div className="relative flex">
-            <div className="mx-auto flex min-h-full w-full flex-col justify-start pt-12 md:max-w-[75%]  lg:max-w-[1013px] lg:px-8 lg:pt-0 xl:min-h-[100vh] xl:max-w-[1383px] xl:px-0 xl:pl-[70px]">
-              <div className="mb-auto flex flex-col pl-5 pr-5 md:pr-0 md:pl-12 lg:max-w-[48%] lg:pl-0 xl:max-w-full">
-                <Link to="/main" className="mt-0 w-max lg:pt-10">
-                  <div className="mx-auto flex h-fit w-fit items-center hover:cursor-pointer">
-                    <svg
-                      width="8"
-                      height="12"
-                      viewBox="0 0 8 12"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M6.70994 2.11997L2.82994 5.99997L6.70994 9.87997C7.09994 10.27 7.09994 10.9 6.70994 11.29C6.31994 11.68 5.68994 11.68 5.29994 11.29L0.709941 6.69997C0.319941 6.30997 0.319941 5.67997 0.709941 5.28997L5.29994 0.699971C5.68994 0.309971 6.31994 0.309971 6.70994 0.699971C7.08994 1.08997 7.09994 1.72997 6.70994 2.11997V2.11997Z"
-                        fill="#A3AED0"
-                      />
-                    </svg>
-                    <p className="ml-3 text-sm text-gray-600">
-                      Back to Dashboard
-                    </p>
-                  </div>
-                </Link>
-                <Routes>
-                  {getRoutes(routes)}
-                  <Route
-                    path="/"
-                    element={<Navigate to="/auth/sign-in" replace />}
-                  />
-                </Routes>
-                <div className="absolute right-0 hidden h-full min-h-screen md:block lg:w-[49vw] 2xl:w-[44vw]">
-                  <div
-                    className="absolute flex h-full w-full items-end justify-center bg-cover bg-center lg:rounded-bl-[120px] xl:rounded-bl-[200px]"
-                    style={{ backgroundImage: `url(${authImg})` }}
-                  />
-                </div>
-              </div>
-              <Footer />
-            </div>
-          </div>
-        </main>
+    <div className="min-h-screen bg-white">
+      <Navbar
+        logoText={"PicktartUp"}
+        brandText={currentRoute}
+        {...rest}
+      />
+      <div className="pt-[20px]"> {/* Reduced padding-top from 100px to 60px */}
+      <Routes>
+          {/* 명시적인 라우트 매칭 */}
+          <Route path="/sign-in" element={<SignIn />} />
+          <Route path="/signup/step1" element={<SignUpStep1 />} />
+          <Route path="/signup/step2" element={<SignUpStep2 />} />
+          <Route path="/" element={<Navigate to="/auth/sign-in" replace />} />
+          <Route path="*" element={<Navigate to="/auth/sign-in" replace />} />
+        </Routes>
       </div>
     </div>
   );

--- a/src/routes.js
+++ b/src/routes.js
@@ -12,6 +12,8 @@ import DetailPage from "views/main/default/details";  // 이 줄 추가
 
 // Auth Imports
 import SignIn from "views/auth/SignIn";
+import SignUpStep1 from "views/auth/SignUpStep1";
+import SignUpStep2 from "views/auth/SignUpStep2";
 
 // Icon Imports
 import {
@@ -20,6 +22,7 @@ import {
   MdBarChart,
   MdPerson,
   MdLock,
+  MdPersonAdd,
 } from "react-icons/md";
 
 const routes = [
@@ -71,6 +74,20 @@ const routes = [
     path: "sign-in",
     icon: <MdLock className="h-6 w-6" />,
     component: <SignIn />,
+  },
+  {
+    name: "Sign Up Step 1",
+    layout: "/auth",
+    path: "signup/step1",
+    icon: <MdPersonAdd className="h-6 w-6" />,
+    component: <SignUpStep1 />,
+  },
+  {
+    name: "Sign Up Step 2",
+    layout: "/auth",
+    path: "signup/step2",
+    icon: <MdPersonAdd className="h-6 w-6" />,
+    component: <SignUpStep2 />,
   },
 ];
 export default routes;

--- a/src/views/auth/SignIn.jsx
+++ b/src/views/auth/SignIn.jsx
@@ -1,80 +1,186 @@
-import InputField from "components/fields/InputField";
-import { FcGoogle } from "react-icons/fc";
-import Checkbox from "components/checkbox";
+// src/views/auth/SignIn.jsx
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import authlogo from "assets/img/logo.png";
+import axios from 'axios';
 
-export default function SignIn() {
+const SignIn = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const response = await axios.post('http://localhost:8080/api/v1/users/public/login', {
+        email,
+        password
+      });
+
+      if (response.data.success && response.data.code === 200) {
+        const { tokenType, accessToken, refreshToken, accessTokenExpireDate } = response.data.data;
+        
+        // 토큰 정보 저장
+        localStorage.setItem('tokenType', tokenType);
+        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
+        localStorage.setItem('accessTokenExpireDate', accessTokenExpireDate);
+        
+        // axios 기본 헤더 설정
+        axios.defaults.headers.common['Authorization'] = `${tokenType} ${accessToken}`;
+        
+        // 로그인 성공 후 리다이렉트
+        navigate('/main/default');
+      }
+    } catch (error) {
+      console.error('Login failed:', error);
+      if (error.response) {
+        alert(error.response.data.message || '로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.');
+      } else {
+        alert('로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
+  };
+
   return (
-    <div className="mt-16 mb-16 flex h-full w-full items-center justify-center px-2 md:mx-0 md:px-0 lg:mb-10 lg:items-center lg:justify-start">
-      {/* Sign in section */}
-      <div className="mt-[10vh] w-full max-w-full flex-col items-center md:pl-4 lg:pl-0 xl:max-w-[420px]">
-        <h4 className="mb-2.5 text-4xl font-bold text-navy-700 dark:text-white">
-          Sign In
-        </h4>
-        <p className="mb-9 ml-1 text-base text-gray-600">
-          Enter your email and password to sign in!
+    <div className="flex min-h-screen flex-col items-center justify-center px-4">
+      {/* Logo and Title */}
+      <div className="text-center mb-6 max-w-[400px]">
+        <img
+          src={authlogo}
+          alt="PicktartUp"
+          className="mx-auto h-24 w-auto mb-4"
+        />
+        <h2 className="text-xl font-extrabold text-gray-900 mb-1">
+          로그인하고 나만의 스타트업에 투자해보세요
+        </h2>
+        <p className="text-sm text-gray-500">
+          PKN 토큰으로 투명하고 안전하게 스타트업에 투자하세요
         </p>
-        <div className="mb-6 flex h-[50px] w-full items-center justify-center gap-2 rounded-xl bg-lightPrimary hover:cursor-pointer dark:bg-navy-800">
-          <div className="rounded-full text-xl">
-            <FcGoogle />
-          </div>
-          <h5 className="text-sm font-medium text-navy-700 dark:text-white">
-            Sign In with Google
-          </h5>
-        </div>
-        <div className="mb-6 flex items-center  gap-3">
-          <div className="h-px w-full bg-gray-200 dark:bg-navy-700" />
-          <p className="text-base text-gray-600 dark:text-white"> or </p>
-          <div className="h-px w-full bg-gray-200 dark:bg-navy-700" />
-        </div>
-        {/* Email */}
-        <InputField
-          variant="auth"
-          extra="mb-3"
-          label="Email*"
-          placeholder="mail@simmmple.com"
-          id="email"
-          type="text"
-        />
+      </div>
 
-        {/* Password */}
-        <InputField
-          variant="auth"
-          extra="mb-3"
-          label="Password*"
-          placeholder="Min. 8 characters"
-          id="password"
-          type="password"
-        />
-        {/* Checkbox */}
-        <div className="mb-4 flex items-center justify-between px-2">
-          <div className="flex items-center">
-            <Checkbox />
-            <p className="ml-2 text-sm font-medium text-navy-700 dark:text-white">
-              Keep me logged In
-            </p>
+      {/* Login Form */}
+      <div className="w-full max-w-[360px] mb-12">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label 
+              htmlFor="email" 
+              className="block text-sm font-medium text-black-700 mb-1"
+            >
+              이메일
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="example@picktartup.com"
+            />
           </div>
-          <a
-            className="text-sm font-medium text-brand-500 hover:text-brand-600 dark:text-white"
-            href=" "
+
+          <div>
+            <label 
+              htmlFor="password" 
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              비밀번호
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+
+          <div className="flex items-center justify-between text-sm">
+            <div className="flex items-center">
+              <input
+                id="remember-me"
+                type="checkbox"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+              />
+              <label 
+                htmlFor="remember-me" 
+                className="ml-2 text-sm text-black-600"
+              >
+                로그인 유지
+              </label>
+            </div>
+            <div>
+              <Link 
+                to="/forgot-password" 
+                className="text-sm text-indigo-600 hover:text-indigo-500"
+              >
+                아이디・비밀번호 찾기
+              </Link>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
           >
-            Forgot Password?
-          </a>
+            로그인
+          </button>
+        </form>
+
+        <div className="mt-6 text-center text-sm">
+          <span className="text-gray-600">아직 아이디가 없으신가요? </span>
+          <Link 
+            to="/auth/signup/step1" 
+            className="text-indigo-700 hover:text-indigo-500"
+          >
+            회원가입
+          </Link>
         </div>
-        <button className="linear mt-2 w-full rounded-xl bg-brand-500 py-[12px] text-base font-medium text-white transition duration-200 hover:bg-brand-600 active:bg-brand-700 dark:bg-brand-400 dark:text-white dark:hover:bg-brand-300 dark:active:bg-brand-200">
-          Sign In
-        </button>
-        <div className="mt-4">
-          <span className=" text-sm font-medium text-navy-700 dark:text-gray-600">
-            Not registered yet?
-          </span>
-          <a
-            href=" "
-            className="ml-1 text-sm font-medium text-brand-500 hover:text-brand-600 dark:text-white"
-          >
-            Create an account
-          </a>
+      </div>
+
+      {/* Feature cards */}
+      <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-6 max-w-[920px] px-4">
+        <div className="text-center">
+          <div className="text-indigo-500 flex justify-center mb-3">
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+          </div>
+          <h3 className="text-base font-medium text-gray-900">토큰 기반 투자</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            블록체인 기술로 구현된 토큰으로 소액부터 투자가 가능합니다.
+          </p>
+        </div>
+        <div className="text-center">
+          <div className="text-indigo-500 flex justify-center mb-3">
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+          </div>
+          <h3 className="text-base font-medium text-gray-900">투명한 거래</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            모든 거래 내역이 블록체인에 기록되어 투명하게 관리됩니다.
+          </p>
+        </div>
+        <div className="text-center">
+          <div className="text-indigo-500 flex justify-center mb-3">
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+          </div>
+          <h3 className="text-base font-medium text-gray-900">안전한 보관</h3>
+          <p className="mt-1 text-sm text-gray-600">
+            디지털 자산을 안전하게 보관하고 관리할 수 있습니다.
+          </p>
         </div>
       </div>
     </div>
   );
-}
+};
+
+export default SignIn;

--- a/src/views/auth/SignUpStep1.jsx
+++ b/src/views/auth/SignUpStep1.jsx
@@ -1,0 +1,501 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import authlogo from "assets/img/logo.png";
+import Steps from 'components/signup/Steps';
+import axios from 'axios';
+
+const TermsModal = ({ isOpen, onClose, title, content }) => {
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Overlay with blur effect */}
+      <div 
+        className="fixed inset-0 z-40"
+        style={{ backgroundColor: 'rgba(0, 0, 0, 0.4)' }}
+        onClick={onClose}
+      />
+      
+      
+{/* Modal */}
+<div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-0">
+  <div className="relative transform overflow-hidden rounded-lg bg-white shadow-xl transition-all w-full max-w-2xl">
+    {/* Header */}
+    <div className="border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+      <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+      <button
+        onClick={onClose}
+        className="rounded-md text-gray-400 hover:text-gray-500 focus:outline-none"
+      >
+        <span className="sr-only">Close</span>
+        <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+          {/* Content */}
+          <div className="px-6 py-4 overflow-y-auto" style={{ maxHeight: 'calc(85vh - 100px)' }}>
+            <div className="prose prose-sm max-w-none">
+              {/* 이용약관인 경우 */}
+              {title === '이용약관' && (
+                <div className="space-y-6">
+                  <div className="mb-8">
+                    <h3 className="text-lg font-bold text-gray-800 mb-4">제1장 총칙</h3>
+                    
+                    <div className="space-y-6">
+                      <div className="space-y-2">
+                        <h4 className="font-semibold">제1조 (목적)</h4>
+                        <p className="text-gray-600 ml-4">
+                          본 약관은 PicktartUp(이하 "회사")이 제공하는 스타트업 조각투자 서비스...
+                        </p>
+                      </div>
+
+                      <div className="space-y-2">
+                        <h4 className="font-semibold">제2조 (용어의 정의)</h4>
+                        <ul className="ml-4 space-y-2">
+                          <li className="text-gray-600">1. "이용자"란 본 서비스를 이용하는 개인, 법인 또는 단체를 의미합니다.</li>
+                          <li className="text-gray-600">2. "조각투자"란 스타트업 지분을 PKN 토큰으로 분할하여 투자할 수 있는 서비스를 의미합니다.</li>
+                          <li className="text-gray-600">3. "NFT(Non-Fungible Token)"란 회사가 발행하거나 이용자가 등록한 고유한 디지털 자산을 의미합니다.</li>
+                          <li className="text-gray-600">4. "PKN 토큰"이란 블록체인 기술을 기반으로 한 회사의 투자 토큰을 의미합니다.</li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* 개인정보 처리방침인 경우 */}
+              {title === '개인정보 처리방침' && (
+                <div className="space-y-6">       
+                  <div className="space-y-6">
+                    <div className="space-y-4">
+                      <h3 className="text-lg font-semibold">1. 수집항목</h3>
+                      <ul className="ml-4 space-y-2">
+                        <li className="text-gray-600">1. 필수항목: 이름, 이메일 주소, 비밀번호, 휴대폰 번호, 계좌정보</li>
+                        <li className="text-gray-600">2. 선택항목: 투자 관심 분야, 투자 경험, 직업, 소득수준</li>
+                        <li className="text-gray-600">3. 자동수집항목: IP 주소, 접속 로그, 쿠키</li>
+                      </ul>
+                    </div>
+                    
+                    <div className="space-y-4">
+                      <h3 className="text-lg font-semibold">2. 수집 및 이용목적</h3>
+                      <ul className="ml-4 space-y-2">
+                        <li className="text-gray-600">1. 서비스 제공 및 계약 이행</li>
+                        <li className="text-gray-600">2. NFT 발행 및 거래 내역 관리</li>
+                        <li className="text-gray-600">3. 투자 정보 제공 및 스타트업 매칭</li>
+                        <li className="text-gray-600">4. 블록체인 지갑 생성 및 관리</li>
+                        <li className="text-gray-600">5. 맞춤형 투자 추천 및 분석</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* 마케팅 정보 수신 동의인 경우 */}
+              {title === '마케팅 정보 수신 동의' && (
+                <div className="space-y-6">      
+                  <div className="space-y-6">
+                    <div className="space-y-4">
+                      <h3 className="text-lg font-semibold">1. 수신 정보 내용</h3>
+                      <ul className="ml-4 space-y-2">
+                        <li className="text-gray-600">1. 신규 투자 상품 및 NFT 발행 정보</li>
+                        <li className="text-gray-600">2. 투자 시장 동향 및 데이터 리포트</li>
+                        <li className="text-gray-600">3. 이벤트, 프로모션 및 경품 정보</li>
+                        <li className="text-gray-600">4. PicktartUp의 기술 및 서비스 업데이트 소식</li>
+                      </ul>
+                    </div>
+                    
+                    <div className="space-y-4">
+                      <h3 className="text-lg font-semibold">2. 수신 방법</h3>
+                      <ul className="ml-4 space-y-2">
+                        <li className="text-gray-600">1. 이메일</li>
+                        <li className="text-gray-600">2. 문자메시지</li>
+                        <li className="text-gray-600">3. 앱 푸시 알림</li>
+                      </ul>
+                    </div>
+                    
+                    <div className="space-y-4">
+                      <h3 className="text-lg font-semibold">3. 마케팅 정보 활용 목적</h3>
+                      <ul className="ml-4 space-y-2">
+                        <li className="text-gray-600">1. 이용자 관심사에 맞춘 맞춤형 투자 정보 제공</li>
+                        <li className="text-gray-600">2. NFT 신규 발행 및 추천</li>
+                        <li className="text-gray-600">3. PKN 토큰 활용 캠페인 및 혜택 안내</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const SignUpStep1 = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    username: '',
+    email: '',
+    password: '',
+    passwordConfirm: ''
+  });
+
+  const [modalState, setModalState] = useState({
+    isOpen: false,
+    title: '',
+    content: ''
+  });
+
+  const [agreements, setAgreements] = useState({
+    all: false,
+    terms: false,
+    privacy: false,
+    marketing: false
+  });
+
+  const termsContent = {
+    terms: `제1장 총칙
+  
+    제1조 (목적)
+    본 약관은 PicktartUp(이하 "회사")이 제공하는 스타트업 조각투자 서비스, NFT 발행 및 거래 플랫폼, PKN 토큰 기반 투자 서비스와 관련하여 이용자와 회사 간의 권리, 의무 및 책임사항을 규정함을 목적으로 합니다.
+    
+    제2조 (용어의 정의)
+    1. "이용자"란 본 서비스를 이용하는 개인, 법인 또는 단체를 의미합니다.
+    2. "조각투자"란 스타트업 지분을 PKN 토큰으로 분할하여 투자할 수 있는 서비스를 의미합니다.
+    3. "NFT(Non-Fungible Token)"란 회사가 발행하거나 이용자가 등록한 고유한 디지털 자산을 의미합니다.
+    4. "PKN 토큰"이란 블록체인 기술을 기반으로 한 회사의 투자 토큰을 의미합니다.
+    
+    제3조 (투자 위험 고지)
+    1. 투자자는 스타트업 조각투자와 NFT 거래에 따른 원금 손실 등 투자위험이 있음을 이해하고, 회사는 투자손실에 대한 책임을 지지 않습니다.
+    2. NFT는 법적 소유권을 보장하지 않으며, 디지털 자산에 대한 소유 및 거래만을 목적으로 합니다.
+    
+    제4조 (서비스 이용)
+    1. 회사는 이용자에게 다음과 같은 서비스를 제공합니다.
+      - 스타트업 조각투자 및 PKN 토큰 관리
+      - NFT 발행 및 거래
+      - 투자 데이터 분석 및 보고
+    2. 서비스 이용 중 이용자의 책임 있는 사유로 발생한 손해는 회사가 책임지지 않습니다.
+    
+    제5조 (이용자의 의무)
+    1. 이용자는 본 서비스 이용 시 법령 및 약관을 준수하여야 합니다.
+    2. 허위 정보를 제공하거나, 서비스 운영을 방해하는 행위를 해서는 안 됩니다.
+    3. 블록체인 지갑의 개인 키 및 비밀번호 관리는 이용자 본인의 책임입니다.
+      `,
+      privacy: `개인정보 수집 및 이용 동의
+    
+    1. 수집항목
+    - 필수항목: 이름, 이메일 주소, 비밀번호, 휴대폰 번호, 계좌정보
+    - 선택항목: 투자 관심 분야, NFT 거래 이력, 직업, 소득수준
+    - 자동수집항목: IP 주소, 접속 로그, 블록체인 지갑 주소
+    
+    2. 수집 및 이용목적
+    - 서비스 제공 및 계약 이행
+    - NFT 발행 및 거래 내역 관리
+    - 투자 정보 제공 및 스타트업 매칭
+    - 블록체인 지갑 생성 및 관리
+    - 맞춤형 투자 추천 및 분석
+    
+    3. 보유 및 이용기간
+    회원 탈퇴 시까지 (관계 법령에 따라 보존할 필요가 있는 경우 해당 기간까지)
+    `,
+      marketing: `마케팅 정보 수신 동의
+    
+    1. 수신 정보 내용
+    - 신규 투자 상품 및 NFT 발행 정보
+    - 투자 시장 동향 및 데이터 리포트
+    - 이벤트, 프로모션 및 경품 정보
+    - PicktartUp의 기술 및 서비스 업데이트 소식
+    
+    2. 수신 방법
+    - 이메일
+    - 문자메시지
+    - 앱 푸시 알림 
+    
+    3. 마케팅 정보 활용 목적
+    - 이용자 관심사에 맞춘 맞춤형 투자 정보 제공
+    - NFT 신규 발행 및 추천
+    - PKN 토큰 활용 캠페인 및 혜택 안내
+    `
+    };
+  
+  const handleModalOpen = (type) => {
+    setModalState({
+      isOpen: true,
+      title: type === 'terms' ? '이용약관' : 
+             type === 'privacy' ? '개인정보 처리방침' : '마케팅 정보 수신 동의',
+      content: termsContent[type]
+    });
+  };
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const handleCheckboxChange = (e) => {
+    const { name, checked } = e.target;
+    if (name === 'all') {
+      setAgreements({
+        all: checked,
+        terms: checked,
+        privacy: checked,
+        marketing: checked
+      });
+    } else {
+      const newAgreements = {
+        ...agreements,
+        [name]: checked
+      };
+      setAgreements({
+        ...newAgreements,
+        all: newAgreements.terms && newAgreements.privacy && newAgreements.marketing
+      });
+    }
+  };
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    // 중복 제출 방지
+    if (isSubmitting) return;
+
+    // 비밀번호 확인
+    if (formData.password !== formData.passwordConfirm) {
+      alert('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    // 필수 약관 동의 확인
+    if (!agreements.terms || !agreements.privacy) {
+      alert('필수 약관에 동의해주세요.');
+      return;
+    }
+
+    const requestData = {
+      username: formData.username,
+      email: formData.email,
+      password: formData.password
+    };
+
+    try {
+      setIsSubmitting(true); // 제출 시작
+
+      // 회원가입 API 호출
+      const response = await axios.post('http://192.168.0.143:32450/user/api/v1/users/public/register', requestData);
+
+      if (response.data.success) {
+        // 회원가입 성공 시 다음 단계로 이동
+        navigate('/auth/signup/step2', {
+          state: {
+            formData,
+            userId: response.data.data // 서버로부터 받은 userId 전달
+          }
+        });
+      } else {
+        throw new Error('회원가입 실패'); // 성공 여부에 따른 추가 처리
+      }
+    } catch (error) {
+      console.error('Register error:', error);
+
+      // 서버에서 보내준 에러 메시지 또는 기본 메시지
+      const errorMessage = error.response?.data?.message || '회원가입 중 오류가 발생했습니다. 다시 시도해주세요.';
+      alert(errorMessage);
+    } finally {
+      setIsSubmitting(false); // 제출 완료
+    }
+  };
+
+
+  return (
+    <div className="flex min-h-screen flex-col items-center pt-10 px-4">
+      <div className="text-center mb-6">
+        <img
+          src={authlogo}
+          alt="PicktartUp"
+          className="mx-auto h-14 w-auto mb-4"
+        />
+        <h2 className="text-xl font-semibold text-gray-900 mb-1">
+          이메일로 회원가입
+        </h2>
+        <p className="text-sm text-gray-500">
+          스타트업 투자의 시작, PicktartUp
+        </p>
+      </div>
+
+      <Steps currentStep={1} />
+
+      <div className="w-full max-w-[400px]">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              이름
+            </label>
+            <input
+              type="text"
+              name="username"
+              required
+              value={formData.username}
+              onChange={handleInputChange}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="이름을 입력해주세요"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              이메일
+            </label>
+            <input
+              type="email"
+              name="email"
+              required
+              value={formData.email}
+              onChange={handleInputChange}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="example@picktartup.com"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              비밀번호
+            </label>
+            <input
+              type="password"
+              name="password"
+              required
+              value={formData.password}
+              onChange={handleInputChange}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="영문, 숫자, 특수문자 포함 8자 이상"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              비밀번호 확인
+            </label>
+            <input
+              type="password"
+              name="passwordConfirm"
+              required
+              value={formData.passwordConfirm}
+              onChange={handleInputChange}
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm text-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder="비밀번호를 한번 더 입력해주세요"
+            />
+          </div>
+
+          <div className="mt-6 space-y-4">
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                name="all"
+                checked={agreements.all}
+                onChange={handleCheckboxChange}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+              />
+              <label className="ml-2 text-sm font-medium text-gray-700">
+                전체 동의
+              </label>
+            </div>
+            
+            <div className="flex items-center justify-between">
+              <div className="flex items-center">
+                <input
+                  type="checkbox"
+                  name="terms"
+                  checked={agreements.terms}
+                  onChange={handleCheckboxChange}
+                  required
+                  className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                />
+                <label className="ml-2 text-sm text-gray-600">
+                  이용약관 동의 (필수)
+                </label>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleModalOpen('terms')}
+                className="text-sm text-indigo-600 hover:text-indigo-500"
+              >
+                전문보기
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="flex items-center">
+                <input
+                  type="checkbox"
+                  name="privacy"
+                  checked={agreements.privacy}
+                  onChange={handleCheckboxChange}
+                  required
+                  className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                />
+                <label className="ml-2 text-sm text-gray-600">
+                  개인정보 수집・이용 동의 (필수)
+                </label>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleModalOpen('privacy')}
+                className="text-sm text-indigo-600 hover:text-indigo-500"
+              >
+                전문보기
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div className="flex items-center">
+                <input
+                  type="checkbox"
+                  name="marketing"
+                  checked={agreements.marketing}
+                  onChange={handleCheckboxChange}
+                  className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                />
+                <label className="ml-2 text-sm text-gray-600">
+                  마케팅 정보 수신 동의 (선택)
+                </label>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleModalOpen('marketing')}
+                className="text-sm text-indigo-600 hover:text-indigo-500"
+              >
+                전문보기
+              </button>
+            </div>
+          </div>
+
+          <button
+          type="submit"
+          disabled={isSubmitting}
+          className="mt-6 w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:bg-indigo-400 disabled:cursor-not-allowed"
+        >
+          {isSubmitting ? '처리중...' : '다음 단계'}
+        </button>
+        </form>
+      </div>
+
+      <TermsModal 
+        isOpen={modalState.isOpen}
+        onClose={() => setModalState({...modalState, isOpen: false})}
+        title={modalState.title}
+        content={modalState.content}
+      />
+    </div>
+  );
+};
+
+export default SignUpStep1;

--- a/src/views/auth/SignUpStep2.jsx
+++ b/src/views/auth/SignUpStep2.jsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import WalletSuccessDialog from 'components/signup/WalletSuccessDialog';
+import authlogo from "assets/img/logo.png";
+import Steps from 'components/signup/Steps';
+import axios from 'axios';
+
+const SignUpStep2 = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { userId } = location.state || {};
+  const [isCreatingWallet, setIsCreatingWallet] = useState(false);
+  const [showSuccessDialog, setShowSuccessDialog] = useState(false);
+  const [walletData, setWalletData] = useState(null);
+
+  const handleCreateWallet = async () => {
+    setIsCreatingWallet(true);
+    
+    try {
+      const response = await axios.post('http://192.168.0.143:32450/wallet/api/v1/wallets', {
+        userId: userId
+      });
+
+      if (response.data.success) {
+        setWalletData(response.data.data);
+        setShowSuccessDialog(true);
+      }
+    } catch (error) {
+      console.error('Wallet creation failed:', error);
+      if (error.response) {
+        alert(error.response.data.message || '지갑 생성에 실패했습니다. 다시 시도해주세요.');
+      } else {
+        alert('서버와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } finally {
+      setIsCreatingWallet(false);
+    }
+  };
+
+  if (!userId) {
+    alert('사용자 ID가 제공되지 않았습니다.');
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center pt-10 px-4">
+      <div className="text-center mb-6">
+        <img
+          src={authlogo}
+          alt="PicktartUp"
+          className="mx-auto h-14 w-auto mb-4"
+        />
+      </div>
+
+      <Steps currentStep={2} />
+
+      <div className="w-full max-w-[400px] text-center">
+        <div className="bg-white p-6 rounded-lg shadow-lg">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">
+            토큰 지갑 생성
+          </h2>
+          <p className="text-sm text-gray-600 mb-6">
+            PKN 토큰을 안전하게 보관하고 관리할 수 있는 지갑을 생성합니다.
+          </p>
+          <div className="space-y-4">
+            <div className="p-4 bg-gray-50 rounded-lg">
+              <p className="text-sm text-gray-600">
+                • 지갑 생성 후에는 수정이 불가능합니다
+              </p>
+              <p className="text-sm text-gray-600">
+                • 생성된 지갑 주소는 마이페이지에서 확인할 수 있습니다
+              </p>
+              <p className="text-sm text-gray-600">
+                • 개인키는 안전하게 보관됩니다
+              </p>
+            </div>
+            <button
+              onClick={handleCreateWallet}
+              disabled={isCreatingWallet}
+              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:bg-indigo-400"
+            >
+              {isCreatingWallet ? '지갑 생성 중...' : '지갑 생성하기'}
+            </button>
+          </div>
+        </div>
+      </div>
+      {showSuccessDialog && walletData && (
+        <WalletSuccessDialog walletData={walletData} />
+      )}
+    </div>
+  );
+};
+
+export default SignUpStep2;


### PR DESCRIPTION
### 👀 관련 이슈  
- #26 

### ✨ 작업한 내용  
- 로그인 페이지 구현: 이메일과 비밀번호 입력 기능, 입력값 검증, 로그인 실패 시 오류 메시지 처리
- 회원가입 페이지 구현: 2단계 프로세스(회원 정보 입력, 지갑 정보 생성), 약관 확인 기능 포함
- 키스토어 기반 지갑 생성 및 저장 처리.  
- 회원가입 완료 화면에서 완료 메시지 및 로그인 페이지 이동 버튼 추가

### 🌀 PR Point  
- 지갑 생성 단계의 예외 처리 로직 검토 필요
- 약관 동의 상태 저장 및 검증 방식 리뷰 요청

### 🍰 참고사항  
- 이용 약관 부분 아직 깨지는 부분 있어서 수정 필요합니다.
- 자잘한 에러는 추후에 수정하겠습니다.

### 📷 스크린샷 또는 GIF  
|기능|스크린샷|  
|:--:|:--:|  
|로그인 페이지|<img width="1482" alt="스크린샷 2024-12-01 오후 7 02 22" src="https://github.com/user-attachments/assets/7393d168-1f9f-4f59-9ff4-22f79f82506f">|  
|회원가입 1단계|<img width="1512" alt="스크린샷 2024-12-02 오후 4 43 09" src="https://github.com/user-attachments/assets/b8188e9a-acc7-4d5f-a5a4-ff6beb0582aa">|  
|이용 약관 확인|<img width="1320" alt="스크린샷 2024-12-02 오후 4 42 59" src="https://github.com/user-attachments/assets/1ac0967c-8ff3-4e51-a0dd-0c747200dcce">|  
|이용 약관 확인2|<img width="1217" alt="스크린샷 2024-12-02 오후 4 43 05" src="https://github.com/user-attachments/assets/41dd3a4d-57cb-42d9-bbd5-b3930202c330">|  
|비밀번호 불일치 에러|<img width="1202" alt="스크린샷 2024-12-02 오후 4 43 27" src="https://github.com/user-attachments/assets/5a61314d-57fa-4223-8ae9-4ae2ba61d827">|  
|회원가입 2단계|<img width="1226" alt="스크린샷 2024-12-02 오후 4 43 40" src="https://github.com/user-attachments/assets/8f49df52-32e7-4ba4-8ec0-e059802f6b22">|  
|회원가입 진행중|<img width="1230" alt="스크린샷 2024-12-02 오후 4 43 44" src="https://github.com/user-attachments/assets/e017ee05-6536-46f3-b6a4-45bb37e60049">|  
|회원가입 완료 화면|<img width="1229" alt="스크린샷 2024-12-02 오후 4 42 25" src="https://github.com/user-attachments/assets/403a18c2-ae21-495a-b39d-85060d043b6e">|  
|로그인으로 리다이렉트|<img width="1193" alt="스크린샷 2024-12-02 오후 5 20 43" src="https://github.com/user-attachments/assets/6efddc6c-a636-4827-b292-e8854d51468b">|  
