### PR TITLE
fix: Coin 서비스에 요청 시 userId 사용

### DIFF
--- a/src/views/main/token/components/ExchangeTable.jsx
+++ b/src/views/main/token/components/ExchangeTable.jsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import axios from "axios";
 
 const ExchangeTable = ({ balance }) => {
+  const userId = 3;
+
   const [exchangeAmount, setExchangeAmount] = useState("");
   const [selectedBank, setSelectedBank] = useState("");
   const [accountNumber, setAccountNumber] = useState("");
@@ -36,7 +38,7 @@ const ExchangeTable = ({ balance }) => {
 
     try {
       const response = await axios.post("/api/v1/coins/exchange", {
-        walletId: 1,
+        userId: userId,
         exchangeAmount: Number(exchangeAmount),
         exchangeBank: selectedBank,
         exchangeAccount: accountNumber,

--- a/src/views/main/token/components/PurchaseTable.jsx
+++ b/src/views/main/token/components/PurchaseTable.jsx
@@ -18,6 +18,8 @@ const products = [
 ];
 
 const PurchaseTable = () => {
+  const userId = 3;
+
   const navigate = useNavigate();
 
   async function requestPayment(coin, price) {
@@ -49,7 +51,9 @@ const PurchaseTable = () => {
 
     // 결제 성공 알림 표시
     alert("결제가 성공적으로 완료되었습니다!");
-
+ 
+    console.log("결제 coin:", coin);
+    console.log("paymentId:", paymentId);
 
     // 서버에 결제 검증 요청
     const notified = await fetch("/api/v1/coins/purchase", {
@@ -57,7 +61,7 @@ const PurchaseTable = () => {
       headers: { "Content-Type": "application/json" },
       // paymentId와 주문 정보를 서버에 전달합니다
       body: JSON.stringify({
-        walletId: 1,          // TODO: 로그인한 유저 정보로 수정
+        userId: userId,          // TODO: 로그인한 유저 정보로 수정
         amount: price,
         coin: Number(coin),
         paymentId: paymentId,

--- a/src/views/main/token/index.jsx
+++ b/src/views/main/token/index.jsx
@@ -8,6 +8,8 @@ import HistoryTable from "./components/HistoryTable";
 import ExchangeTable from "./components/ExchangeTable";
 
 const Tables = () => {
+  const userId = 3;
+
   const historyTableTitle = "토큰 구매/현금화 내역";
   const [apiData, setApiData] = useState(null);
   const [error, setError] = useState(null);
@@ -20,7 +22,7 @@ const Tables = () => {
 
     const fetchBalance = async () => {
       try {
-        const response = await fetch('/api/v1/coins/balance?walletId=1'); // TODO: 수정
+        const response = await fetch(`/api/v1/coins/balance?userId=${userId}`);
         const data = await response.json();
         setBalance(data.data);
       } catch (error) {
@@ -33,7 +35,7 @@ const Tables = () => {
   const fetchMenuData = async (menu) => {
     if (menu === "history" && tableData.length > 0) return;
 
-    const endpoint = "/api/v1/coins/purchases?userId=1";
+    const endpoint = `/api/v1/coins/purchases?userId=${userId}`;
 
     try {
       const response = await axios.get(endpoint);


### PR DESCRIPTION
### ✨ 작업한 내용
- Coin 서비스에 요청 시 walletId 대신 userId 사용
  - 잔액 조회
  - 거래 내역 조회
  - 코인 구매 
  - 코인 현금화
