### PR TITLE
cicd: EKS와 온프레미스 K8S에서의 API 처리 방식 변경

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -35,41 +35,50 @@ server {
     }
 
     # API 요청 라우팅
+    location /api/v1/contracts/ {
+        proxy_pass http://192.168.0.142:32450/contract;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /api/v1/wallets/ {
+        proxy_pass http://192.168.0.142:32450/wallet;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /api/v1/admin/ {
+        proxy_pass http://192.168.0.142:32450/admin;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+        proxy_set_header Connection keep-alive;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    #location /api/v1/users/ {
+    #    proxy_pass https://picktartup.com/user/;
+    #    proxy_set_header Host $host;
+    #}
+
+    #location /api/v1/coins/ {
+    #    proxy_pass https://picktartup.com/coin/;
+    #    proxy_set_header Host $host;
+    #}
+
+    #location /api/v1/startups/ {
+    #    proxy_pass https://picktartup.com/startup/;
+    #    proxy_set_header Host $host;
+    #}
+    
     #location /api/v1/users/ {
     #    proxy_pass http://172.20.184.53:8080/; # userservice ClusterIP와 포트
     #    proxy_set_header Host $host;
     #    proxy_http_version 1.1;
     #}
-    
-    location /api/v1/users/ {
-        proxy_pass https://picktartup.com/user/;
-        proxy_set_header Host $host;
-    }
-
-    location /api/v1/coins/ {
-        proxy_pass https://picktartup.com/coin/;
-        proxy_set_header Host $host;
-    }
-
-    location /api/v1/contracts/ {
-        proxy_pass http://192.168.0.142:32450/contract/;
-        proxy_set_header Host $host;
-    }
-
-    location /api/v1/wallets/ {
-        proxy_pass http://192.168.0.142:32450/wallet/;
-        proxy_set_header Host $host;
-    }
-
-    location /api/v1/startups/ {
-        proxy_pass https://picktartup.com/startup/;
-        proxy_set_header Host $host;
-    }
-
-    location /api/v1/admin/ {
-        proxy_pass http://192.168.0.142:32450/admin/;
-        proxy_set_header Host $host;
-    }
     
     # API 프록시 설정 (필요한 경우)
     # location /api/ {


### PR DESCRIPTION
### ✨ 작업한 내용
- EKS: 도메인 뒤에 호출하는 api 주소 그대로 병합
- Vanilla K8S: 온프레미스 서비스 뒤에 호출하는 api 주소 병합
