### PR TITLE
🐛fix: iframe의 sandbox 속성 변경

### DIFF
--- a/src/views/admin/NetworkMonitoring.jsx
+++ b/src/views/admin/NetworkMonitoring.jsx
@@ -259,7 +259,7 @@ const ServiceCard = ({ service, environment }) => {
             <iframe 
                 src={getGrafanaUrl(service)}
                 className="w-full h-full"
-                sandbox="allow-scripts allow-same-origin"
+                sandbox="allow-scripts allow-same-origin allow-forms"
                 referrerPolicy="no-referrer"
                 frameBorder="0"
                 title={`${service.displayName} Network Metrics`}
@@ -347,7 +347,7 @@ const NetworkMonitoring = () => {
          <div className="h-[600px] mt-6">
            <iframe
              src={getOverallGrafanaUrl()}
-             sandbox="allow-scripts allow-same-origin"
+             sandbox="allow-scripts allow-same-origin allow-forms"
               referrerPolicy="no-referrer"
              className="w-full h-full border-0"
              title="Overall Network Performance"


### PR DESCRIPTION
### 👀 관련 이슈
- #67 
- #65 

### ✨ 작업한 내용
**에러**
`
Blocked form submission to '' because the form's frame is sandboxed and the 'allow-forms' permission is not set.
`

**해결**
`
<iframe 
    src={getGrafanaUrl(service)}
    className="w-full h-full"
    sandbox="allow-scripts allow-same-origin allow-forms"  // allow-forms 추가
    referrerPolicy="no-referrer"
    frameBorder="0"
    title={`${service.displayName} Network Metrics`}
/>
`

