### PR TITLE
fix: nginx.conf 중복 설정 병합

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -54,35 +54,31 @@ server {
     location / {
         # HTML5 History API를 사용하는 SPA를 위한 설정
         try_files $uri $uri/ /index.html;
+
         # 캐싱 설정
         expires 30d;
+
         # 보안 헤더 설정
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
+
+        # 캐싱 무효화 (필요 시 활성화)
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires 0;
     }
 
-    # 정적 파일 처리
-    location ~* \.(?:ico|css|js|gif|jpe?g|png|woff2?|eot|ttf|svg|webp)$ {
+    location ~* \.js$ {
+    add_header Content-Type application/javascript always;
+    expires 30d;
+    log_not_found off;
+}
+
+    location ~* \.(?:ico|css|gif|jpe?g|png|woff2?|eot|ttf|svg|webp)$ {
         try_files $uri =404;
         expires 30d;
         access_log off;
         add_header Cache-Control "public";
-        add_header Content-Type application/javascript always;
-    }
-
-    # 추가 MIME 타입 보장 (특히 JS 파일)
-    location ~* \.js$ {
-        add_header Content-Type application/javascript always;
-        expires 30d;
-        log_not_found off;
-    }
-
-    # 캐싱 무효화 (필요 시 활성화)
-    location / {
-        try_files $uri /index.html;
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires 0;
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈
- nginx.conf 파일에서 블록이 중복되어 pod가 제대로 실행되지 않음
![image](https://github.com/user-attachments/assets/8c6f4a17-1ad3-4571-82c9-0011a9eb4445)
![image](https://github.com/user-attachments/assets/b9917c17-f7a6-4baa-b852-bc7f466acb03)

### ✨ 작업한 내용
- 중복 설정 병합
```
    location / {
        # HTML5 History API를 사용하는 SPA를 위한 설정
        try_files $uri $uri/ /index.html;

        # 캐싱 설정
        expires 30d;

        # 보안 헤더 설정
        add_header X-Frame-Options "SAMEORIGIN" always;
        add_header X-XSS-Protection "1; mode=block" always;
        add_header X-Content-Type-Options "nosniff" always;

        # 캐싱 무효화 (필요 시 활성화)
        add_header Cache-Control "no-cache, no-store, must-revalidate";
        add_header Pragma "no-cache";
        add_header Expires 0;
    }

    location ~* \.js$ {
        add_header Content-Type application/javascript always;
        expires 30d;
        log_not_found off;
    }

    location ~* \.(?:ico|css|gif|jpe?g|png|woff2?|eot|ttf|svg|webp)$ {
        try_files $uri =404;
        expires 30d;
        access_log off;
        add_header Cache-Control "public";
    }
```

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||
