### PR TITLE
fix: nginx.conf에 mjs 설정 반영

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -13,68 +13,29 @@ server {
     gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/xml;
     gzip_disable "MSIE [1-6]\.";
 
-    # # 프로메테우스 프록시 설정
-    # location /prometheus/ {
-    #     proxy_pass http://192.168.0.141:30090/;
-    #     proxy_http_version 1.1;
-    #     proxy_set_header Upgrade $http_upgrade;
-    #     proxy_set_header Connection 'upgrade';
-    #     proxy_set_header Host $host;
-    #     proxy_set_header X-Real-IP $remote_addr;
-    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #     proxy_set_header X-Forwarded-Proto $scheme;
-    #     proxy_cache_bypass $http_upgrade;
-    # }
-
-    # # 그라파나 프록시 설정
-    # location /grafana/ {
-    #     proxy_pass http://192.168.0.141:32647/;
-    #     proxy_http_version 1.1;
-    #     proxy_set_header Upgrade $http_upgrade;
-    #     proxy_set_header Connection 'upgrade';
-    #     proxy_set_header Host $host;
-    #     proxy_set_header X-Real-IP $remote_addr;
-    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #     proxy_set_header X-Forwarded-Proto $scheme;
-    #     proxy_cache_bypass $http_upgrade;
-    # }
-
-    # location /kibana/ {
-    #     proxy_pass http://192.168.0.141:32450/;
-    #     proxy_http_version 1.1;
-    #     proxy_set_header Upgrade $http_upgrade;
-    #     proxy_set_header Connection 'upgrade';
-    #     proxy_set_header Host $host;
-    #     proxy_set_header X-Real-IP $remote_addr;
-    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #     proxy_set_header X-Forwarded-Proto $scheme;
-    #     proxy_cache_bypass $http_upgrade;
-    # }
-
     location / {
         # HTML5 History API를 사용하는 SPA를 위한 설정
         try_files $uri $uri/ /index.html;
 
-        # 캐싱 설정
-        expires 30d;
+        # 캐싱 무효화 (SPA 주요 파일의 캐싱 방지)
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires 0;
 
         # 보안 헤더 설정
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header X-Content-Type-Options "nosniff" always;
-
-        # 캐싱 무효화 (필요 시 활성화)
-        add_header Cache-Control "no-cache, no-store, must-revalidate";
-        add_header Pragma "no-cache";
-        add_header Expires 0;
     }
 
-    location ~* \.js$ {
-    add_header Content-Type application/javascript always;
-    expires 30d;
-    log_not_found off;
-}
+    # JavaScript 파일 처리 (.js, .mjs 포함)
+    location ~* \.(js|mjs)$ {
+        add_header Content-Type application/javascript always;
+        expires 30d;
+        log_not_found off;
+    }
 
+    # 정적 파일 처리
     location ~* \.(?:ico|css|gif|jpe?g|png|woff2?|eot|ttf|svg|webp)$ {
         try_files $uri =404;
         expires 30d;


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈 번호를 태그해주세요 (예시: #1)-->

### ✨ 작업한 내용
- nginx.conf에 mjs 설정 반영
```
server {
    listen 80;
    server_name picktartup.com;
    
    root /usr/share/nginx/html;
    index index.html;

    # gzip 압축 설정
    gzip on;
    gzip_vary on;
    gzip_min_length 10240;
    gzip_proxied expired no-cache no-store private auth;
    gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/xml;
    gzip_disable "MSIE [1-6]\.";

    location / {
        # HTML5 History API를 사용하는 SPA를 위한 설정
        try_files $uri $uri/ /index.html;

        # 캐싱 무효화 (SPA 주요 파일의 캐싱 방지)
        add_header Cache-Control "no-cache, no-store, must-revalidate";
        add_header Pragma "no-cache";
        add_header Expires 0;

        # 보안 헤더 설정
        add_header X-Frame-Options "SAMEORIGIN" always;
        add_header X-XSS-Protection "1; mode=block" always;
        add_header X-Content-Type-Options "nosniff" always;
    }

    # JavaScript 파일 처리 (.js, .mjs 포함)
    location ~* \.(js|mjs)$ {
        add_header Content-Type application/javascript always;
        expires 30d;
        log_not_found off;
    }

    # 정적 파일 처리
    location ~* \.(?:ico|css|gif|jpe?g|png|woff2?|eot|ttf|svg|webp)$ {
        try_files $uri =404;
        expires 30d;
        access_log off;
        add_header Cache-Control "public";
    }
}
```

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|||
